### PR TITLE
Remove incorrect use of the term "library"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # syma-drone-controller
-Arduino library and Python serial interface to control a Syma X1C programatically
+Arduino sketch and Python serial interface to control a Syma X1C programatically
 
 
 Based off of controller code found here: https://github.com/goebish/nrf24_multipro


### PR DESCRIPTION
This is a sketch, not a library, so it's incorrect to call it a "library".

This error also occurs in the repository description. That can not be fixed via a pull request but it's easily done by clicking the **Edit** button to the right of the description text shown at the top of the repository's home page:
https://github.com/andrewkouri/syma-drone-controller